### PR TITLE
MouseTrap binds should be removed if the element is removed.

### DIFF
--- a/wMousetrap.js
+++ b/wMousetrap.js
@@ -5,7 +5,7 @@
  * @author Martin Gontovnikas <martin@gon.to>
  * @license MIT License, http://www.opensource.org/licenses/MIT
  */
-angular.module('mgo-mousetrap', []).directive('wMousetrap', ['$parse', function ($parse) {
+angular.module('mgo-mousetrap', []).directive('wMousetrap', function () {
     return {
         restrict: 'A',
         controller: ['$scope', '$element', '$attrs',
@@ -15,7 +15,7 @@ angular.module('mgo-mousetrap', []).directive('wMousetrap', ['$parse', function 
 
             $scope.$watch($attrs.wMousetrap, function(_mousetrap) {
                 mousetrap = _mousetrap;
-                
+
                 for (var key in mousetrap) {
                     if (mousetrap.hasOwnProperty(key)) {
                         Mousetrap.unbind(key);

--- a/wMousetrap.js
+++ b/wMousetrap.js
@@ -11,7 +11,11 @@ angular.module('mgo-mousetrap', []).directive('wMousetrap', ['$parse', function 
         controller: ['$scope', '$element', '$attrs',
                      function ($scope, $element, $attrs) {
             
-            $scope.$watch($attrs.wMousetrap, function(mousetrap) {
+            var mousetrap;
+
+            $scope.$watch($attrs.wMousetrap, function(_mousetrap) {
+                mousetrap = _mousetrap;
+                
                 for (var key in mousetrap) {
                     if (mousetrap.hasOwnProperty(key)) {
                         Mousetrap.unbind(key);
@@ -29,7 +33,8 @@ angular.module('mgo-mousetrap', []).directive('wMousetrap', ['$parse', function 
             }
             
             $element.bind('$destroy', function() {
-                var mousetrap = $parse($attrs.wMousetrap)($scope);
+                if (!mousetrap) return;
+
                 for (var key in mousetrap) {
                     if (mousetrap.hasOwnProperty(key)) {
                         Mousetrap.unbind(key);

--- a/wMousetrap.js
+++ b/wMousetrap.js
@@ -5,7 +5,7 @@
  * @author Martin Gontovnikas <martin@gon.to>
  * @license MIT License, http://www.opensource.org/licenses/MIT
  */
-angular.module('mgo-mousetrap', []).directive('wMousetrap', function () {
+angular.module('mgo-mousetrap', []).directive('wMousetrap', ['$parse', function ($parse) {
     return {
         restrict: 'A',
         controller: ['$scope', '$element', '$attrs',
@@ -28,6 +28,15 @@ angular.module('mgo-mousetrap', []).directive('wMousetrap', function () {
                 };
             }
             
+            $element.bind('$destroy', function() {
+                var mousetrap = $parse($attrs.wMousetrap)($scope);
+                for (var key in mousetrap) {
+                    if (mousetrap.hasOwnProperty(key)) {
+                        Mousetrap.unbind(key);
+                    }
+                }
+            });
+
         }]
     }
-});
+}]);


### PR DESCRIPTION
I have implemented this directive in my application, and found out that the binds are kept alive - even though the element which declared them has been removed long ago.

I'm pretty sure that the expected behavior is to remove the binds if the element is removed.

This Pull Request fixes it.
