### PR TITLE
A fix to MouseTrap binds should be removed if the element is removed.

### DIFF
--- a/wMousetrap.js
+++ b/wMousetrap.js
@@ -44,4 +44,4 @@ angular.module('mgo-mousetrap', []).directive('wMousetrap', function () {
 
         }]
     }
-}]);
+});


### PR DESCRIPTION
I've left an unnecessary "]" at the end of the directive declaration, it's fixed now. 
