### PR TITLE
Add params as to function Fix #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ $scope.superCoolAction = function(event) {
 }
 ````
 
+Let's check a example with custom parameters (require v0.1.0 or higher):
+````html
+<input type="button" value="Make super cool action" ng-click="superCoolActionWithParams()" w-mousetrap="{'command+shift+p': [superCoolActionWithParams, scopeVariable, 'myCustomString'}" />
+````
+
+````js
+$scope.scopeVariable = {a: 'A', b: 'B', c: [1,2,3,4]};
+
+$scope.superCoolActionWithParams = function(event, params) {
+    event.preventDefault();
+    console.log("Super cool with params", params);
+    //returns [scopeVariable, 'myCustomString]
+}
+````
+
+
 Hope you guys like this!!!
 
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $scope.superCoolAction = function(event) {
 }
 ````
 
-Let's check a example with custom parameters (require v0.1.0 or higher):
+Let's check an example with custom parameters (require v0.2.0 or higher):
 ````html
 <input type="button" value="Make super cool action" ng-click="superCoolActionWithParams()" w-mousetrap="{'command+shift+p': [superCoolActionWithParams, scopeVariable, 'myCustomString'}" />
 ````

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "mgo-mousetrap",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "main": "./wMousetrap.js",
   "description": "Handling keyboard interaction on an Angular app: An Angular Mousetrap wrapper",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mgo-mousetrap",
   "description": "Handling keyboard interaction on an Angular app: An Angular Mousetrap wrapper",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "filename": "wMousetrap.js",
   "main": "./wMousetrap.js",
   "homepage": "https://github.com/mgonto/mgo-mousetrap",

--- a/wMousetrap.js
+++ b/wMousetrap.js
@@ -1,6 +1,6 @@
 /**
  * Mousetrap wrapper for AngularJS
- * @version v0.0.1 - 2013-12-30
+ * @version v0.1.0 - 2015-11-30
  * @link https://github.com/mgonto/mgo-mousetrap
  * @author Martin Gontovnikas <martin@gon.to>
  * @license MIT License, http://www.opensource.org/licenses/MIT
@@ -23,11 +23,17 @@ angular.module('mgo-mousetrap', []).directive('wMousetrap', function () {
                     }
                 }
             }, true);
-            
-            function applyWrapper(func) {
+
+            function applyWrapper(fnc) {
+                var func = fnc[0] || fnc,
+                    params = [];
+                if (angular.isArray(fnc)) {
+                    fnc.shift();
+                    params = fnc;
+                }
                 return function(e) {
                     $scope.$apply(function() {
-                        func(e);
+                        func(e, params);
                     });
                 };
             }

--- a/wMousetrap.js
+++ b/wMousetrap.js
@@ -1,6 +1,6 @@
 /**
  * Mousetrap wrapper for AngularJS
- * @version v0.1.0 - 2015-11-30
+ * @version v0.2.0 - 2015-11-30
  * @link https://github.com/mgonto/mgo-mousetrap
  * @author Martin Gontovnikas <martin@gon.to>
  * @license MIT License, http://www.opensource.org/licenses/MIT


### PR DESCRIPTION
Fix issue #6 adding params as array.

Needs to pass as array while the function must be the first parameter.

Usage:

``` html

<div w-mousetrap="{ a: [someFunc, scopeVariable, 'string variable'] }">
```

``` javascript

$scope.someFunc = function(event, params) {
    event.preventDefault();
    console.log("Super cool", params);
};
```
